### PR TITLE
Optimisations in JNI.

### DIFF
--- a/src/main/java/io/sqooba/traildb/TrailDB.java
+++ b/src/main/java/io/sqooba/traildb/TrailDB.java
@@ -1,10 +1,8 @@
 package io.sqooba.traildb;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -31,7 +29,7 @@ public class TrailDB implements AutoCloseable {
     private long numTrails;
     private long numEvents;
     private long numFields;
-    private List<String> fields;
+    String[] fields;
 
     private TrailDB(TrailDBBuilder builder) {
         this(builder.path);
@@ -60,10 +58,10 @@ public class TrailDB implements AutoCloseable {
         this.numTrails = this.trailDBj.numTrails(this.db);
         this.numEvents = this.trailDBj.numEvents(this.db);
         this.numFields = this.trailDBj.numFields(this.db);
-        this.fields = new ArrayList<>((int)this.numFields);
+        this.fields = new String[(int)this.numFields];
 
         for(int i = 0; i < this.numFields; i++) {
-            this.fields.add(this.trailDBj.getFieldName(this.db, i));
+            this.fields[i] = this.trailDBj.getFieldName(this.db, i);
         }
     }
 
@@ -74,6 +72,10 @@ public class TrailDB implements AutoCloseable {
      */
     public long length() {
         return this.numTrails;
+    }
+
+    public long getNumEvents() {
+        return this.numEvents;
     }
 
     /**
@@ -123,7 +125,7 @@ public class TrailDB implements AutoCloseable {
      * @throws TrailDBException if the specified field is not found.
      */
     public long getField(String fieldName) {
-        long index = this.fields.indexOf(fieldName);
+        long index = Arrays.asList(this.fields).indexOf(fieldName);
         if (index == -1) {
             throw new TrailDBException("Failed to retreive field. Field not found");
         }
@@ -292,8 +294,7 @@ public class TrailDB implements AutoCloseable {
         if (errCode != 0) {
             throw new TrailDBException("Failed to create cursor with code: " + errCode);
         }
-        TrailDBEvent e = new TrailDBEvent(this, this.fields);
-        return new TrailDBIterator(cursor, e);
+        return new TrailDBIterator(cursor, this);
     }
 
     /**

--- a/src/main/java/io/sqooba/traildb/TrailDBInterface.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBInterface.java
@@ -77,5 +77,5 @@ public interface TrailDBInterface {
 
     public long getTrailLength(ByteBuffer cursor);
 
-    public int cursorNext(ByteBuffer cursor, TrailDBEvent event); // Fill the event in jni.
+    public TrailDBEvent cursorNext(ByteBuffer cursor);
 }

--- a/src/main/java/io/sqooba/traildb/TrailDBIterator.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBIterator.java
@@ -38,7 +38,7 @@ public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
                 if (!TrailDBIterator.this.event.isBuilt()) {
                     TrailDBNative.INSTANCE.cursorNext(TrailDBIterator.this.cursor, TrailDBIterator.this.event);
                 }
-                return new TrailDBEvent(TrailDBIterator.this.event);
+                return TrailDBIterator.this.event;
             }
 
             @Override
@@ -51,5 +51,9 @@ public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
                 throw new UnsupportedOperationException();
             }
         };
+    }
+
+    public TrailDBEvent getCurrentEvent() {
+        return new TrailDBEvent(TrailDBIterator.this.event);
     }
 }

--- a/src/main/java/io/sqooba/traildb/TrailDBIterator.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBIterator.java
@@ -14,11 +14,14 @@ import java.util.Iterator;
 public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
 
     private ByteBuffer cursor;
-    private TrailDBEvent event;
+    private boolean built = false;
+    private TrailDB trailDB;
+    private long size;
 
-    protected TrailDBIterator(ByteBuffer cursor, TrailDBEvent event) {
-        this.event = event;
+    protected TrailDBIterator(ByteBuffer cursor, TrailDB trailDB) {
         this.cursor = cursor;
+        this.trailDB = trailDB;
+        this.size = trailDB.getNumEvents();
     }
 
     @Override
@@ -33,17 +36,28 @@ public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
     public Iterator<TrailDBEvent> iterator() {
         return new Iterator<TrailDBEvent>() {
 
+            private TrailDBEvent event;
+
             @Override
             public TrailDBEvent next() {
-                if (!TrailDBIterator.this.event.isBuilt()) {
-                    TrailDBNative.INSTANCE.cursorNext(TrailDBIterator.this.cursor, TrailDBIterator.this.event);
+                if (!TrailDBIterator.this.built) {
+                    this.event = TrailDBNative.INSTANCE.cursorNext(TrailDBIterator.this.cursor);
+                    TrailDBIterator.this.built = true;
                 }
-                return TrailDBIterator.this.event;
+                this.event.build(TrailDBIterator.this.trailDB, TrailDBIterator.this.trailDB.fields);
+                return this.event;
             }
 
             @Override
             public boolean hasNext() {
-                return TrailDBNative.INSTANCE.cursorNext(TrailDBIterator.this.cursor, TrailDBIterator.this.event) == 0;
+                TrailDBEvent next = TrailDBNative.INSTANCE.cursorNext(TrailDBIterator.this.cursor);
+                if (next == null) {
+                    return false;
+                } else {
+                    this.event = next;
+                    TrailDBIterator.this.built = true;
+                    return true;
+                }
             }
 
             @Override
@@ -51,9 +65,5 @@ public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
                 throw new UnsupportedOperationException();
             }
         };
-    }
-
-    public TrailDBEvent getCurrentEvent() {
-        return new TrailDBEvent(TrailDBIterator.this.event);
     }
 }

--- a/src/main/java/io/sqooba/traildb/TrailDBNative.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBNative.java
@@ -205,7 +205,7 @@ public enum TrailDBNative implements TrailDBInterface {
     private native long tdbGetTrailLength(ByteBuffer cursor);
 
     /** const tdb_event *tdb_cursor_next(tdb_cursor *cursor) */
-    private native int tdbCursorNext(ByteBuffer cursor, TrailDBEvent event); // Fill the event in jni.
+    private native TrailDBEvent tdbCursorNext(ByteBuffer cursor);
 
     @Override
     public ByteBuffer consInit() {
@@ -349,7 +349,7 @@ public enum TrailDBNative implements TrailDBInterface {
     }
 
     @Override
-    public int cursorNext(ByteBuffer cursor, TrailDBEvent event) {
-        return tdbCursorNext(cursor, event);
+    public TrailDBEvent cursorNext(ByteBuffer cursor) {
+        return tdbCursorNext(cursor);
     }
 }

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
@@ -34,10 +34,9 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 void JNI_OnUnload(JavaVM *vm, void *reserved) {
     JNIEnv* env;
     if (vm->GetEnv((void **) &env, JNI_VERSION_1_6) != JNI_OK) {
-        // Something is wrong but nothing we can do about this :(
         return;
     } else {
-        if (0 != NULL){
+        if (traildbEvent != NULL){
             env->DeleteGlobalRef(traildbEvent);
         }
     }

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
@@ -499,9 +499,6 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
 	}
 	
 	// Construct event.
-	//jclass cls = env->FindClass("io/sqooba/traildb/TrailDBEvent");
-	//jmethodID midBuild = env->GetMethodID(cls, "build","(JJ)V");
-	//jmethodID midAdd = env->GetMethodID(cls, "addItem","(J)V");
 	env->CallObjectMethod(jevent, JMID_traildbEvent_build, (jlong)timestamp, (jlong)num_items);
 
 	unsigned int j;

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.h
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.h
@@ -234,10 +234,10 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbCursorNext
- * Signature: (Ljava/nio/ByteBuffer;Lio/sqooba/traildb/TrailDBEvent;)I
+ * Signature: (Ljava/nio/ByteBuffer;)Lio/sqooba/traildb/TrailDBEvent2;
  */
-JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
-  (JNIEnv *, jobject, jobject, jobject);
+JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
+  (JNIEnv *, jobject, jobject);
 
 #ifdef __cplusplus
 }

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.h
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.h
@@ -234,7 +234,7 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbCursorNext
- * Signature: (Ljava/nio/ByteBuffer;)Lio/sqooba/traildb/TrailDBEvent2;
+ * Signature: (Ljava/nio/ByteBuffer;)Lio/sqooba/traildb/TrailDBEvent;
  */
 JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
   (JNIEnv *, jobject, jobject);

--- a/src/test/java/io/sqooba/traildb/test/TrailDBTest.java
+++ b/src/test/java/io/sqooba/traildb/test/TrailDBTest.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
@@ -18,9 +17,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import io.sqooba.traildb.TrailDB;
-import io.sqooba.traildb.TrailDBIterator;
-import io.sqooba.traildb.TrailDBException;
 import io.sqooba.traildb.TrailDBEvent;
+import io.sqooba.traildb.TrailDBException;
+import io.sqooba.traildb.TrailDBIterator;
 import io.sqooba.traildb.TrailDBNative;
 import mockit.Deencapsulation;
 
@@ -77,16 +76,13 @@ public class TrailDBTest {
     public void trailShouldContainCorrectTrailDBEvents() {
         TrailDBIterator trail = this.db.trail(0);
         TrailDBEvent e = trail.iterator().next();
-        List<String> fieldsNames = e.getFieldNames();
-        List<String> fieldsValues = e.getFieldsValues();
+        String[] fieldsNames = e.getFieldNames();
 
         assertEquals(122, e.getTimestamp());
         assertEquals(2, e.getNumItems());
-        assertEquals("time", fieldsNames.get(0));
-        assertEquals("field1", fieldsNames.get(1));
-        assertEquals("field2", fieldsNames.get(2));
-        assertEquals("kaguya", fieldsValues.get(0));
-        assertEquals("hinata", fieldsValues.get(1));
+        assertEquals("time", fieldsNames[0]);
+        assertEquals("field1", fieldsNames[1]);
+        assertEquals("field2", fieldsNames[2]);
         assertEquals("Event(time=122, field1=kaguya, field2=hinata)", e.toString());
     }
 


### PR DESCRIPTION
Some optimisations have been done in JNI, like caching the Java classes names and method ids.

The JNI method that calls tdb_cursor_next now construct a TrailDBEvent in place and returns it instead of calling Java methods to fill a pre-existent one.