### PR TITLE
Clean upload directory during deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,8 @@ jobs:
         on:
           branch: master
           tags: true
+      after_deploy:
+      - git checkout -b master
+      - git add pom.xml
+      - git commit -m "🤖 Update pom version."
+      - git push

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,8 @@ jobs:
       sudo: required
       before_install:
       - ./install.sh
-      install:
-      - ./download_mac.sh
-      script:
-      - mvn clean install -DskipTests
+      install: true
+      script: skip
       deploy:
         skip_cleanup: true
         provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,3 @@ jobs:
         on:
           branch: master
           tags: true
-      after_deploy:
-      - git checkout -b master
-      - git add pom.xml
-      - git commit -m "🤖 Update pom version."
-      - git push

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp .travis.settings.xml $HOME/.m2/settings.xml
+mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$TRAVIS_TAG
+mvn clean deploy -DSkipTests

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-cp .travis.settings.xml $HOME/.m2/settings.xml
-mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$TRAVIS_TAG
-mvn clean deploy -DSkipTests

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+./download_mac.sh
+mvn clean install -DskipTests
 cp .travis.settings.xml $HOME/.m2/settings.xml
 mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$TRAVIS_TAG
 mvn clean deploy -DSkipTests

--- a/download_mac.sh
+++ b/download_mac.sh
@@ -2,5 +2,10 @@
 
 sudo apt-get install -qq sshpass
 gem install package_cloud
+
+# Download the mac library.
 sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 -r $SSH_USER@185.19.29.18:/upload down/
+# Cleanup.
+sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< $'rm 'libtraildbjava-$TRAVIS_TAG'.dylib'
+# Rename so it can be used by maven.
 mv libtraildbjava-$TRAVIS_TAG.dylib libtraildbjava.dylib

--- a/download_mac.sh
+++ b/download_mac.sh
@@ -3,3 +3,4 @@
 sudo apt-get install -qq sshpass
 gem install package_cloud
 sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 -r $SSH_USER@185.19.29.18:/upload down/
+mv libtraildbjava-$TRAVIS_TAG.dylib libtraildbjava.dylib

--- a/download_mac.sh
+++ b/download_mac.sh
@@ -6,6 +6,6 @@ gem install package_cloud
 # Download the mac library.
 sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 -r $SSH_USER@185.19.29.18:/upload down/
 # Cleanup.
-sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< $'rm 'libtraildbjava-$TRAVIS_TAG'.dylib'
+sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< "rm libtraildbjava-$TRAVIS_TAG.dylib"
 # Rename so it can be used by maven.
 mv libtraildbjava-$TRAVIS_TAG.dylib libtraildbjava.dylib

--- a/download_mac.sh
+++ b/download_mac.sh
@@ -4,8 +4,8 @@ sudo apt-get install -qq sshpass
 gem install package_cloud
 
 # Download the mac library.
-sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 -r $SSH_USER@185.19.29.18:/upload down/
+sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< "get libtraildbjava.dylib-$TRAVIS_TAG"
 # Cleanup.
-sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< "rm libtraildbjava-$TRAVIS_TAG.dylib"
+sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< "rm libtraildbjava.dylib-$TRAVIS_TAG"
 # Rename so it can be used by maven.
-mv libtraildbjava-$TRAVIS_TAG.dylib libtraildbjava.dylib
+mv libtraildbjava.dylib-$TRAVIS_TAG libtraildbjava.dylib

--- a/upload_mac.sh
+++ b/upload_mac.sh
@@ -2,4 +2,4 @@
 
 jar -xf target/traildb.jar libtraildbjava.dylib
 mv libtraildbjava.dylib libtraildbjava-$TRAVIS_TAG.dylib
-sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< $'put 'libtraildbjava-$TRAVIS_TAG'.dylib'
+sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< "put libtraildbjava-$TRAVIS_TAG.dylib"

--- a/upload_mac.sh
+++ b/upload_mac.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 jar -xf target/traildb.jar libtraildbjava.dylib
-mv libtraildbjava.dylib libtraildbjava-$TRAVIS_TAG.dylib
-sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< "put libtraildbjava-$TRAVIS_TAG.dylib"
+mv libtraildbjava.dylib libtraildbjava.dylib-$TRAVIS_TAG
+sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< "put libtraildbjava.dylib-$TRAVIS_TAG"

--- a/upload_mac.sh
+++ b/upload_mac.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 jar -xf target/traildb.jar libtraildbjava.dylib
-sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< $'put libtraildbjava.dylib'
+mv libtraildbjava.dylib libtraildbjava-$TRAVIS_TAG.dylib
+sshpass -p $SSH_PASS sftp -oStrictHostKeyChecking=no -oPort=2223 $SSH_USER@185.19.29.18:/upload <<< $'put 'libtraildbjava-$TRAVIS_TAG'.dylib'


### PR DESCRIPTION
Change name of uploaded mac lib so it is unique and clear the directory after downloading it back.