### PR TITLE
🚑 Correct location for the dylib file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
         </extensions>
         <resources>
             <resource>
-                <directory>down</directory>
+                <directory>.</directory>
                 <filtering>true</filtering>
                 <includes>
                     <include>*.dylib</include>


### PR DESCRIPTION
The pom resource directory was referencing an old directory not existing anymore which was preventing the inclusion of the .dylib file into the deployed jar.