### PR TITLE
🐎 Optimise iterators.

### DIFF
--- a/src/main/java/io/sqooba/traildb/TrailDB.java
+++ b/src/main/java/io/sqooba/traildb/TrailDB.java
@@ -99,7 +99,7 @@ public class TrailDB implements AutoCloseable {
     public long getMaxTimestamp() {
         final long max = this.trailDBj.maxTimestamp(this.db);
         if (max < 0) {
-            LOGGER.warn("long overflow, received a negtive value for max timestamp.");
+            LOGGER.warn("long overflow, received a negative value for max timestamp.");
         }
         return max;
     }

--- a/src/main/java/io/sqooba/traildb/TrailDB.java
+++ b/src/main/java/io/sqooba/traildb/TrailDB.java
@@ -290,13 +290,22 @@ public class TrailDB implements AutoCloseable {
         if (cursor == null) {
             throw new TrailDBException("Memory allocation failed for cursor.");
         }
-        // FIXME
+        
+        // Init cursor for the current trail.
         int errCode = this.trailDBj.getTrail(cursor, trailID);
+        if (errCode != 0) {
+            throw new TrailDBException("Failed to create cursor with code: " + errCode);
+        }
+        
+        // Get the size of the trail, used in the iterator.
         int size = (int)trailDBj.getTrailLength(cursor);
+        
+        // We have to get the trail again because getTrailLength consumes the cursor.
         errCode = this.trailDBj.getTrail(cursor, trailID);
         if (errCode != 0) {
             throw new TrailDBException("Failed to create cursor with code: " + errCode);
         }
+        
         return new TrailDBIterator(cursor, this, size);
     }
 

--- a/src/main/java/io/sqooba/traildb/TrailDB.java
+++ b/src/main/java/io/sqooba/traildb/TrailDB.java
@@ -290,11 +290,14 @@ public class TrailDB implements AutoCloseable {
         if (cursor == null) {
             throw new TrailDBException("Memory allocation failed for cursor.");
         }
+        // FIXME
         int errCode = this.trailDBj.getTrail(cursor, trailID);
+        int size = (int)trailDBj.getTrailLength(cursor);
+        errCode = this.trailDBj.getTrail(cursor, trailID);
         if (errCode != 0) {
             throw new TrailDBException("Failed to create cursor with code: " + errCode);
         }
-        return new TrailDBIterator(cursor, this);
+        return new TrailDBIterator(cursor, this, size);
     }
 
     /**

--- a/src/main/java/io/sqooba/traildb/TrailDB.java
+++ b/src/main/java/io/sqooba/traildb/TrailDB.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Class used to query an existing TrailDB.
- * 
+ *
  * @author B. Sottas
  *
  */
@@ -21,14 +21,14 @@ public class TrailDB implements AutoCloseable {
     /** 8 bytes are need to represents 64 bits. */
     private static final int UINT64 = 8;
 
-    private TrailDBNative trailDBj = TrailDBNative.INSTANCE;
+    private final TrailDBNative trailDBj = TrailDBNative.INSTANCE;
 
     /** ByteBuffer holding a pointer to the traildb. */
     ByteBuffer db;
 
-    private long numTrails;
-    private long numEvents;
-    private long numFields;
+    private final long numTrails;
+    private final long numEvents;
+    private final long numFields;
     String[] fields;
 
     private TrailDB(TrailDBBuilder builder) {
@@ -37,7 +37,7 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Construct a TrailDB on the given .tdb file.
-     * 
+     *
      * @param path The path to the TrailDB file.
      * @throws TrailDBException If TrailDB initialisation fails.
      */
@@ -67,7 +67,7 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Return the number of trails in the TrailDB.
-     * 
+     *
      * @return The number of trails.
      */
     public long length() {
@@ -80,11 +80,11 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get the oldest timestamp.
-     * 
+     *
      * @return The oldest timestamp.
      */
     public long getMinTimestamp() {
-        long min = this.trailDBj.minTimestamp(this.db);
+        final long min = this.trailDBj.minTimestamp(this.db);
         if (min < 0) {
             LOGGER.warn("long overflow, received a negtive value for min timestamp.");
         }
@@ -93,11 +93,11 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get the newest timestamp.
-     * 
+     *
      * @return The newest timestmap.
      */
     public long getMaxTimestamp() {
-        long max = this.trailDBj.maxTimestamp(this.db);
+        final long max = this.trailDBj.maxTimestamp(this.db);
         if (max < 0) {
             LOGGER.warn("long overflow, received a negtive value for max timestamp.");
         }
@@ -106,11 +106,11 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get the version.
-     * 
+     *
      * @return The version.
      */
     public long getVersion() {
-        long version = this.trailDBj.version(this.db);
+        final long version = this.trailDBj.version(this.db);
         if (version < 0) {
             LOGGER.warn("version overflow.");
         }
@@ -119,13 +119,13 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get the field ID given a field name.
-     * 
+     *
      * @param fieldName The field name.
      * @return The corresponding field ID.
      * @throws TrailDBException if the specified field is not found.
      */
     public long getField(String fieldName) {
-        long index = Arrays.asList(this.fields).indexOf(fieldName);
+        final long index = Arrays.asList(this.fields).indexOf(fieldName);
         if (index == -1) {
             throw new TrailDBException("Failed to retreive field. Field not found");
         }
@@ -134,13 +134,13 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get the number of distinct values in the given field, +1 counting the empty string if not present.
-     * 
+     *
      * @param field The field ID.
      * @return The number of distinct values.
      * @throws TrailDBException if the field index is invalid ( <=0 | > number of fields).
      */
     public long getLexiconSize(long field) {
-        long value = this.trailDBj.lexiconSize(this.db, field);
+        final long value = this.trailDBj.lexiconSize(this.db, field);
         if (value == 0) {
             throw new TrailDBException("Invalid field index.");
         }
@@ -149,13 +149,13 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get the field name given a field ID.
-     * 
+     *
      * @param fieldId The field ID.
      * @return The corresponding field name.
      * @throws TrailDBException if the field id is invalid ( <=0 | > number of fields).
      */
     public String getFieldName(long fieldId) {
-        String res = this.trailDBj.getFieldName(this.db, fieldId);
+        final String res = this.trailDBj.getFieldName(this.db, fieldId);
         if (res == null) {
             throw new TrailDBException("Invalid field id.");
         }
@@ -165,16 +165,16 @@ public class TrailDB implements AutoCloseable {
     /**
      * <p>Get the item corresponding to a value. Note that this is a relatively slow operation that may need to scan
      * through all values in the field.
-     * 
+     *
      * <p> WARNING: the returned value maybe suffer overflow!
-     * 
+     *
      * @param fieldID The field ID.
      * @param value The value in the field.
      * @return An item encoded in a long, which was casted from uint64_t.
      * @throws TrailDBException if no item is found.
      */
     public long getItem(long fieldID, String value) {
-        long item = this.trailDBj.getItem(this.db, fieldID, value);
+        final long item = this.trailDBj.getItem(this.db, fieldID, value);
         if (item == 0) {
             throw new TrailDBException("No item found.");
         }
@@ -186,21 +186,21 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * <p> Get the value corresponding to a field ID and value ID pair.
-     * 
+     *
      * <p> Calling with the empty string for {@code val} will result in an error.
-     * 
+     *
      * @param field The field ID.
      * @param val The value ID.
      * @return The corresponding field value.
      * @throws TrailDBException if the returned value is too big for Java or not found in the db.
      */
     public String getValue(long field, long val) {
-        ByteBuffer bb = ByteBuffer.allocate(8);
-        String value = this.trailDBj.getValue(this.db, field, val, bb);
+        final ByteBuffer bb = ByteBuffer.allocate(8);
+        final String value = this.trailDBj.getValue(this.db, field, val, bb);
         if (value == null) {
             throw new TrailDBException("Error reading value.");
         }
-        long value_length = bb.getLong(0);
+        final long value_length = bb.getLong(0);
         if (value_length > Integer.MAX_VALUE) {
             throw new TrailDBException(
                     "Overflow, received a String value that is larger than the java String capacity.");
@@ -210,18 +210,18 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get the value corresponding to an item. This is a shorthand version of getValue().
-     * 
+     *
      * @param item The item.
      * @return The corresponding field value.
      * @throws TrailDBException if the value was not found or the returned value is too big for Java.
      */
     public String getItemValue(long item) {
-        ByteBuffer bb = ByteBuffer.allocate(8);
-        String value = this.trailDBj.getItemValue(this.db, item, bb);
+        final ByteBuffer bb = ByteBuffer.allocate(8);
+        final String value = this.trailDBj.getItemValue(this.db, item, bb);
         if (value == null) {
             throw new TrailDBException("Value not found.");
         }
-        long value_length = bb.getLong(0);
+        final long value_length = bb.getLong(0);
         if (value_length > Integer.MAX_VALUE) {
             throw new TrailDBException(
                     "Overflow, received a String value that is larger than the java String capacity.");
@@ -231,7 +231,7 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get the UUID given a trail ID.
-     * 
+     *
      * @param trailID The trail ID.
      * @return A raw 16-byte UUID.
      * @throws TrailDBException if the {@code trailID} is invalid i.e. less than 0 or greater than the number of trails.
@@ -242,12 +242,12 @@ public class TrailDB implements AutoCloseable {
             throw new IllegalArgumentException("Invalid trail ID.");
         }
 
-        ByteBuffer uuid = this.trailDBj.getUUID(this.db, trailID);
+        final ByteBuffer uuid = this.trailDBj.getUUID(this.db, trailID);
         if (uuid == null) {
             throw new TrailDBException("Invalid trail ID.");
         }
 
-        byte[] bytes = new byte[uuid.capacity()];
+        final byte[] bytes = new byte[uuid.capacity()];
         uuid.position(0);
         uuid.get(bytes, 0, uuid.capacity());
         return this.trailDBj.UUIDHex(bytes);
@@ -262,16 +262,16 @@ public class TrailDB implements AutoCloseable {
      * @throws IllegalArgumentException If {@code uuid} is an invalid 32-byte hex string.
      */
     public long getTrailID(String uuid) {
-        ByteBuffer trailID = ByteBuffer.allocate(UINT64);
-        byte[] rawUUID = this.trailDBj.UUIDRaw(uuid);
+        final ByteBuffer trailID = ByteBuffer.allocate(UINT64);
+        final byte[] rawUUID = this.trailDBj.UUIDRaw(uuid);
         if (rawUUID == null) {
             throw new IllegalArgumentException("Invalid UUID.");
         }
-        int errCode = this.trailDBj.getTrailId(this.db, rawUUID, trailID);
+        final int errCode = this.trailDBj.getTrailId(this.db, rawUUID, trailID);
         if (errCode != 0) {
             throw new TrailDBException("UUID not found. " + errCode);
         }
-        long res = trailID.getLong(0);
+        final long res = trailID.getLong(0);
         if (res < 0) {
             LOGGER.warn("Received trail ID overflow: " + res);
         }
@@ -280,43 +280,43 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Get a cursor over a particular trail in the database. The cursor allows to iterate over events in this trail.
-     * 
+     *
      * @param trailID The trail id.
      * @return A cursor over the trail.
      * @throws TrailDBException If cursor creation failed in some way.
      */
     public TrailDBIterator trail(long trailID) { // Python has more params.
-        ByteBuffer cursor = this.trailDBj.cursorNew(this.db);
+        final ByteBuffer cursor = this.trailDBj.cursorNew(this.db);
         if (cursor == null) {
             throw new TrailDBException("Memory allocation failed for cursor.");
         }
-        
+
         // Init cursor for the current trail.
         int errCode = this.trailDBj.getTrail(cursor, trailID);
         if (errCode != 0) {
             throw new TrailDBException("Failed to create cursor with code: " + errCode);
         }
-        
+
         // Get the size of the trail, used in the iterator.
-        int size = (int)trailDBj.getTrailLength(cursor);
-        
+        final int size = (int)this.trailDBj.getTrailLength(cursor);
+
         // We have to get the trail again because getTrailLength consumes the cursor.
         errCode = this.trailDBj.getTrail(cursor, trailID);
         if (errCode != 0) {
             throw new TrailDBException("Failed to create cursor with code: " + errCode);
         }
-        
+
         return new TrailDBIterator(cursor, this, size);
     }
 
     /**
      * Get a map containing a trail UUID as key and a trail cursor as value, allowing to iterate over all trails in the
      * database.
-     * 
+     *
      * @return A map containing a trail UUID as key and a trail cursor as value
      */
     public Map<String, TrailDBIterator> trails() {
-        Map<String, TrailDBIterator> res = new HashMap<>();
+        final Map<String, TrailDBIterator> res = new HashMap<>();
         for(int i = 0; i < this.length(); i++) {
             res.put(this.getUUID(i), this.trail(i));
         }
@@ -334,20 +334,20 @@ public class TrailDB implements AutoCloseable {
 
     /**
      * Class allowing to easily construct a new TrailDB.
-     * 
+     *
      * @author B. Sottas
      */
     public static class TrailDBBuilder {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(TrailDBBuilder.class);
 
-        private TrailDBNative trailDBj = TrailDBNative.INSTANCE;
+        private final TrailDBNative trailDBj = TrailDBNative.INSTANCE;
 
         /** New TrailDB output path, without .tdb. */
-        private String path;
+        private final String path;
 
         /** Names of fields in the new TrailDB. */
-        private String[] ofields;
+        private final String[] ofields;
 
         /** Handle to the TrailDB, returned by init method. */
         private ByteBuffer cons;
@@ -357,7 +357,7 @@ public class TrailDB implements AutoCloseable {
 
         /**
          * Build a new TrailDB.
-         * 
+         *
          * @param path TrailDB output path.
          * @param ofields Names of fields.
          * @throws NullPointerException If given path is null.
@@ -386,7 +386,7 @@ public class TrailDB implements AutoCloseable {
 
         /**
          * Add an event to the TrailDB.
-         * 
+         *
          * @param uuid UUID of the event to be added.
          * @param timestamp Event timestamp.
          * @param values Value of each field.
@@ -398,22 +398,22 @@ public class TrailDB implements AutoCloseable {
                 throw new TrailDBException("Trying to add event to an already finalised database.");
             }
 
-            int n = values.length;
+            final int n = values.length;
             if (n != this.ofields.length) {
                 // FIXME this is a hack to avoid random errors in the C lib.
                 // Need to investigate add function in JNI.
                 throw new TrailDBException("Number of values does not match number of fields.");
             }
-            long[] value_lengths = new long[n];
+            final long[] value_lengths = new long[n];
             for(int i = 0; i < n; i++) {
                 value_lengths[i] = values[i].length();
             }
 
-            byte[] rawUUID = this.trailDBj.UUIDRaw(uuid);
+            final byte[] rawUUID = this.trailDBj.UUIDRaw(uuid);
             if (rawUUID == null) {
                 throw new IllegalArgumentException("uuid is invalid.");
             }
-            int errCode = this.trailDBj.consAdd(this.cons, rawUUID, timestamp, values, value_lengths);
+            final int errCode = this.trailDBj.consAdd(this.cons, rawUUID, timestamp, values, value_lengths);
             if (errCode != 0) {
                 throw new TrailDBException("Failed to add: " + errCode);
             }
@@ -424,7 +424,7 @@ public class TrailDB implements AutoCloseable {
         /**
          * Merge an existing TrailDB to this constructor. The fields must be equal between the existing and the new
          * TrailDB.
-         * 
+         *
          * @param db The db to merge to this one.
          * @throws TrailDBException if the merge fails.
          */
@@ -433,7 +433,7 @@ public class TrailDB implements AutoCloseable {
                 throw new TrailDBException("Trying to append to an already finalised database.");
             }
 
-            int errCode = this.trailDBj.consAppend(this.cons, db.db);
+            final int errCode = this.trailDBj.consAppend(this.cons, db.db);
             if (errCode != 0) {
                 throw new TrailDBException("Failed to merge dbs: " + errCode);
             }

--- a/src/main/java/io/sqooba/traildb/TrailDBEvent.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBEvent.java
@@ -18,22 +18,13 @@ public class TrailDBEvent {
     private long timestamp;
     private long numItems;
     private long[] items;
-    private long items2;
 
     /** This one contains the timestamp name. */
     private String[] fieldNames;
-    private String[] fieldValues;
-
-//    protected TrailDBEvent(long timestamp, long numItems, long[] items) {
-//        this.timestamp = timestamp;
-//        this.numItems = numItems;
-//        this.items = Arrays.copyOf(items, (int)numItems);
-//    }
 
     protected TrailDBEvent(TrailDB trailDB, String[] fieldsNames) {
         this.trailDB = trailDB;
         this.fieldNames = fieldsNames;
-        this.fieldValues = new String[fieldNames.length - 1];
     }
 
     protected TrailDBEvent() {

--- a/src/main/java/io/sqooba/traildb/TrailDBEvent.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBEvent.java
@@ -17,22 +17,26 @@ public class TrailDBEvent {
 
     private long timestamp;
     private long numItems;
-    private long[] items; // items encoded on uint64_t.
+    private long[] items;
+    private long items2;
 
     /** This one contains the timestamp name. */
     private String[] fieldNames;
     private String[] fieldValues;
 
-    protected TrailDBEvent(long timestamp, long numItems, long[] items) {
-        this.timestamp = timestamp;
-        this.numItems = numItems;
-        this.items = Arrays.copyOf(items, (int)numItems);
-    }
+//    protected TrailDBEvent(long timestamp, long numItems, long[] items) {
+//        this.timestamp = timestamp;
+//        this.numItems = numItems;
+//        this.items = Arrays.copyOf(items, (int)numItems);
+//    }
 
-    protected void build(TrailDB trailDB, String[] fieldsNames) {
+    protected TrailDBEvent(TrailDB trailDB, String[] fieldsNames) {
         this.trailDB = trailDB;
         this.fieldNames = fieldsNames;
         this.fieldValues = new String[fieldNames.length - 1];
+    }
+
+    protected TrailDBEvent() {
     }
 
     /**

--- a/src/main/java/io/sqooba/traildb/TrailDBInterface.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBInterface.java
@@ -77,5 +77,5 @@ public interface TrailDBInterface {
 
     public long getTrailLength(ByteBuffer cursor);
 
-    public TrailDBEvent cursorNext(ByteBuffer cursor);
+    public int cursorNext(ByteBuffer cursor, TrailDBEvent event);
 }

--- a/src/main/java/io/sqooba/traildb/TrailDBIterator.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBIterator.java
@@ -18,7 +18,6 @@ import java.util.NoSuchElementException;
 public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
 
     private ByteBuffer cursor;
-    private boolean built = true;
     private TrailDB trailDB;
     private long size;
 
@@ -40,8 +39,7 @@ public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
     public Iterator<TrailDBEvent> iterator() {
         return new Iterator<TrailDBEvent>() {
 
-            private TrailDBEvent event = new TrailDBEvent(TrailDBIterator.this.trailDB,
-                    TrailDBIterator.this.trailDB.fields);
+            private TrailDBEvent event = new TrailDBEvent();
             int currIndex = 0;
 
             @Override

--- a/src/main/java/io/sqooba/traildb/TrailDBNative.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBNative.java
@@ -204,8 +204,9 @@ public enum TrailDBNative implements TrailDBInterface {
     /** uint64_t tdb_get_trail_length(tdb_cursor *cursor) */
     private native long tdbGetTrailLength(ByteBuffer cursor);
 
-    /** const tdb_event *tdb_cursor_next(tdb_cursor *cursor) */
-    private native TrailDBEvent tdbCursorNext(ByteBuffer cursor);
+    /** const tdb_event *tdb_cursor_next(tdb_cursor *cursor) 
+     * @param event */
+    private native int tdbCursorNext(ByteBuffer cursor, TrailDBEvent event);
 
     @Override
     public ByteBuffer consInit() {
@@ -349,7 +350,7 @@ public enum TrailDBNative implements TrailDBInterface {
     }
 
     @Override
-    public TrailDBEvent cursorNext(ByteBuffer cursor) {
-        return tdbCursorNext(cursor);
+    public int cursorNext(ByteBuffer cursor, TrailDBEvent event) {
+        return tdbCursorNext(cursor, event);
     }
 }

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
@@ -10,7 +10,9 @@ extern "C" {
 }
 
 static jclass traildbEvent;
-static jmethodID JMID_traildbEvent_constructor;
+static jfieldID JFID_traildbEvent_timestamp;
+static jfieldID JFID_traildbEvent_numItems;
+static jfieldID JFID_traildbEvent_items;
 
 jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 	JNIEnv* env = NULL;
@@ -25,7 +27,10 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         traildbEvent = (jclass) env->NewGlobalRef(tempLocalClassRef);
 		env->DeleteLocalRef(tempLocalClassRef);
 
-		JMID_traildbEvent_constructor = env->GetMethodID(traildbEvent, "<init>","(JJ[J)V");
+		//JMID_traildbEvent_constructor = env->GetMethodID(traildbEvent, "<init>","(JJ[J)V");
+		JFID_traildbEvent_timestamp = env->GetFieldID(traildbEvent, "timestamp", "J");
+		JFID_traildbEvent_numItems = env->GetFieldID(traildbEvent, "numItems", "J");
+		JFID_traildbEvent_items = env->GetFieldID(traildbEvent, "items", "[J");
     } 
 
     return JNI_VERSION_1_6;
@@ -469,8 +474,8 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
 
 }
 
-JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
-  (JNIEnv *env, jobject thisObject, jobject jcursor)
+JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
+  (JNIEnv *env, jobject thisObject, jobject jcursor, jobject jevent)
 {
 
 	// Convert arguments.
@@ -481,27 +486,31 @@ JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
 
 	// Check if there is no more events.
 	if(!event) {
-		return NULL;
+		return -1;
 	}
 
 	// Get struct elements.
 	uint64_t timestamp = event->timestamp;
 	uint64_t num_items = event->num_items;
 	const tdb_item *items_ptr = event->items;
-	jlong items[num_items];
+
+
+  	jlongArray newArray = env->NewLongArray(num_items);
+    jlong *narr = env->GetLongArrayElements(newArray, NULL);
 
 	unsigned int i;
-	for(i = 0; i < num_items; i++) {
-		items[i] = (jlong)items_ptr[i];
-	}
+    for (i = 0; i < num_items; i++) {
+        narr[i] = items_ptr[i];
+    }
 
-	jlongArray result;
- 	result = env->NewLongArray(num_items);
-	env->SetLongArrayRegion(result, 0, num_items, items);
 
-	// Construct and return event.
-	jobject ret = env->NewObject(traildbEvent, JMID_traildbEvent_constructor, (jlong)timestamp, (jlong)num_items, result);
-	return ret;
+	env->SetLongField(jevent, JFID_traildbEvent_timestamp, timestamp);
+	env->SetLongField(jevent, JFID_traildbEvent_numItems, num_items);
+	env->SetObjectField(jevent, JFID_traildbEvent_items, newArray);
+
+    env->ReleaseLongArrayElements(newArray, narr, 0);
+
+	return 0;
 
 }
 

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
@@ -507,7 +507,7 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
 	env->SetLongField(jevent, JFID_traildbEvent_numItems, num_items);
 	env->SetObjectField(jevent, JFID_traildbEvent_items, newArray);
 
-    env->ReleaseLongArrayElements(newArray, narr, 0);
+	env->ReleaseLongArrayElements(newArray, narr, 0);
 
 	return 0;
 

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
@@ -503,7 +503,6 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
         narr[i] = items_ptr[i];
     }
 
-
 	env->SetLongField(jevent, JFID_traildbEvent_timestamp, timestamp);
 	env->SetLongField(jevent, JFID_traildbEvent_numItems, num_items);
 	env->SetObjectField(jevent, JFID_traildbEvent_items, newArray);

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.h
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.h
@@ -234,10 +234,10 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbCursorNext
- * Signature: (Ljava/nio/ByteBuffer;)Lio/sqooba/traildb/TrailDBEvent;
+ * Signature: (Ljava/nio/ByteBuffer;Lio/sqooba/traildb/TrailDBEvent;)I
  */
-JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
-  (JNIEnv *, jobject, jobject);
+JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
+  (JNIEnv *, jobject, jobject, jobject);
 
 #ifdef __cplusplus
 }

--- a/src/test/java/io/sqooba/traildb/test/TrailDBFailureTest.java
+++ b/src/test/java/io/sqooba/traildb/test/TrailDBFailureTest.java
@@ -23,12 +23,12 @@ import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 public class TrailDBFailureTest {
 
-    private TrailDBNative traildb = TrailDBNative.INSTANCE;
+    private final TrailDBNative traildb = TrailDBNative.INSTANCE;
 
     private TrailDB db;
-    private String path = "testdb";
-    private String cookie = "12345678123456781234567812345678";
-    private String otherCookie = "12121212121212121212121212121212";
+    private final String path = "testdb";
+    private final String cookie = "12345678123456781234567812345678";
+    private final String otherCookie = "12121212121212121212121212121212";
 
     private final TestLogger logger = TestLoggerFactory.getTestLogger(TrailDB.class);
 
@@ -39,7 +39,7 @@ public class TrailDBFailureTest {
     public void setUp() throws IOException {
 
         // Initialise a TrailDB with some TrailDBEvents.
-        TrailDBBuilder builder = new TrailDBBuilder(this.path, new String[] { "field1", "field2" });
+        final TrailDBBuilder builder = new TrailDBBuilder(this.path, new String[] { "field1", "field2" });
         builder.add(this.cookie, 120, new String[] { "a", "hinata" });
         builder.add(this.cookie, 121, new String[] { "vilya", "" });
         builder.add(this.otherCookie, 122, new String[] { "kaguya", "hinata" });
@@ -51,7 +51,7 @@ public class TrailDBFailureTest {
     public void tearDown() throws IOException {
 
         // Clear the TrailDB files/directories created for the tests.
-        File f = new File(this.path + ".tdb");
+        final File f = new File(this.path + ".tdb");
         if (f.exists() && !f.isDirectory()) {
             f.delete();
         }
@@ -122,7 +122,7 @@ public class TrailDBFailureTest {
         };
         this.db.getMaxTimestamp();
         assertTrue(this.logger.getLoggingEvents().stream()
-                .anyMatch(e -> "long overflow, received a negtive value for max timestamp.".equals(e.getMessage())));
+                .anyMatch(e -> "long overflow, received a negative value for max timestamp.".equals(e.getMessage())));
     }
 
     @Test


### PR DESCRIPTION
Instead of creating the events on the JNI side, do it on Java side and fill them from JNI. This speeds up the simple count iteration over the database by a factor of  ~1/3 on my machine.

Make the Iterator methods next and hasNext a bit cleaner. Closes #11 .