### PR TITLE
🐎 Improve iterator performances.

### DIFF
--- a/src/main/java/io/sqooba/traildb/TrailDBNative.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBNative.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class is used to perform native call to the TrailDB C library. Base on the available Python bindings.
- * 
+ *
  * @author B. Sottas
  *
  */
@@ -24,7 +24,7 @@ public enum TrailDBNative implements TrailDBInterface {
 
     /**
      * Convert a raw 16-byte UUID into its hexadecimal string representation.
-     * 
+     *
      * @param rawUUID 16-byte UUID.
      * @return A 32-byte hexadecimal string representation.
      */
@@ -34,7 +34,7 @@ public enum TrailDBNative implements TrailDBInterface {
 
     /**
      * Convert a 32-byte hexadecimal string representation of an UUID into a raw 16-byte UUID.
-     * 
+     *
      * @param hexUUID The UUID to be converted.
      * @return The raw 16-byte UUID.
      */
@@ -42,7 +42,7 @@ public enum TrailDBNative implements TrailDBInterface {
         byte[] b = null;
         try {
             b = Hex.decodeHex(hexUUID.toCharArray());
-        } catch(DecoderException e) {
+        } catch(final DecoderException e) {
             LOGGER.error("Failed to convert hexstring to string.", e);
         }
         return b;
@@ -64,7 +64,7 @@ public enum TrailDBNative implements TrailDBInterface {
         name = System.mapLibraryName(name);
         File fileOut = null;
         try {
-            InputStream in = TrailDBNative.class.getResourceAsStream("/" + name);
+            final InputStream in = TrailDBNative.class.getResourceAsStream("/" + name);
 
             if (in == null) {
                 throw new NullPointerException();
@@ -72,7 +72,7 @@ public enum TrailDBNative implements TrailDBInterface {
 
             fileOut = File.createTempFile("traildbjava", name.substring(name.indexOf(".")));
 
-            OutputStream out = FileUtils.openOutputStream(fileOut);
+            final OutputStream out = FileUtils.openOutputStream(fileOut);
             IOUtils.copy(in, out);
             LOGGER.info("Lib copied to: " + fileOut.getAbsolutePath());
             in.close();
@@ -81,7 +81,7 @@ public enum TrailDBNative implements TrailDBInterface {
             fileOut.deleteOnExit();
 
             System.load(fileOut.getAbsolutePath());
-        } catch(Exception e) {
+        } catch(final Exception e) {
             LOGGER.error("Failed to load library.", e);
             System.exit(-1);
         } finally {
@@ -204,9 +204,14 @@ public enum TrailDBNative implements TrailDBInterface {
     /** uint64_t tdb_get_trail_length(tdb_cursor *cursor) */
     private native long tdbGetTrailLength(ByteBuffer cursor);
 
-    /** const tdb_event *tdb_cursor_next(tdb_cursor *cursor) 
-     * @param event */
+    /** const tdb_event *tdb_cursor_next(tdb_cursor *cursor) */
     private native int tdbCursorNext(ByteBuffer cursor, TrailDBEvent event);
+
+    // ========================================================================
+    // Custom.
+    // ========================================================================
+
+    public native String eventGetItemValue(ByteBuffer db, int index, ByteBuffer value_length, TrailDBEvent event);
 
     @Override
     public ByteBuffer consInit() {

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
@@ -27,10 +27,9 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         traildbEvent = (jclass) env->NewGlobalRef(tempLocalClassRef);
 		env->DeleteLocalRef(tempLocalClassRef);
 
-		//JMID_traildbEvent_constructor = env->GetMethodID(traildbEvent, "<init>","(JJ[J)V");
 		JFID_traildbEvent_timestamp = env->GetFieldID(traildbEvent, "timestamp", "J");
 		JFID_traildbEvent_numItems = env->GetFieldID(traildbEvent, "numItems", "J");
-		JFID_traildbEvent_items = env->GetFieldID(traildbEvent, "items", "[J");
+		JFID_traildbEvent_items = env->GetFieldID(traildbEvent, "items", "J");
     } 
 
     return JNI_VERSION_1_6;
@@ -459,7 +458,6 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrail
 
 	// Call lib.
 	return tdb_get_trail(cursor, trail_id);
-
 }
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
@@ -471,7 +469,6 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
 
 	// Call lib.
 	return (jlong) tdb_get_trail_length(cursor);
-
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
@@ -482,35 +479,45 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
 	tdb_cursor *cursor = (tdb_cursor*) env->GetDirectBufferAddress(jcursor);
 
 	// Call lib.
-	const tdb_event *event = tdb_cursor_next(cursor);
+	const tdb_event *event;
+	event = tdb_cursor_next(cursor);
 
 	// Check if there is no more events.
 	if(!event) {
 		return -1;
 	}
 
-	// Get struct elements.
-	uint64_t timestamp = event->timestamp;
-	uint64_t num_items = event->num_items;
-	const tdb_item *items_ptr = event->items;
-
-
-  	jlongArray newArray = env->NewLongArray(num_items);
-    jlong *narr = env->GetLongArrayElements(newArray, NULL);
-
-	unsigned int i;
-    for (i = 0; i < num_items; i++) {
-        narr[i] = items_ptr[i];
-    }
-
-	env->SetLongField(jevent, JFID_traildbEvent_timestamp, timestamp);
-	env->SetLongField(jevent, JFID_traildbEvent_numItems, num_items);
-	env->SetObjectField(jevent, JFID_traildbEvent_items, newArray);
-
-	env->ReleaseLongArrayElements(newArray, narr, 0);
+	// Store field in TrailDBEvent.
+	env->SetLongField(jevent, JFID_traildbEvent_timestamp, event->timestamp);
+	env->SetLongField(jevent, JFID_traildbEvent_numItems, event->num_items);
+	env->SetLongField(jevent, JFID_traildbEvent_items, (long)event->items);
 
 	return 0;
-
 }
+
+JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_eventGetItemValue
+  (JNIEnv *env, jobject thisObject, jobject jdb, jint jindex, jobject jvalueLength, jobject jevent) 
+{
+	
+	// Convert arguments.
+	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	uint64_t value_length;
+
+	jclass jc = env->GetObjectClass(jvalueLength);
+	jmethodID mid = env->GetMethodID(jc, "putLong","(J)Ljava/nio/ByteBuffer;");
+
+	// Get the items pointer.
+	const tdb_item *items;
+	items = (tdb_item *) env->GetLongField(jevent, JFID_traildbEvent_items);
+	
+	// Call lib.
+	const char* v = tdb_get_item_value(db, items[jindex], &value_length);
+
+	// Store to the buffer the what has been put in the pointer.
+	env->CallObjectMethod(jvalueLength, mid, value_length);
+
+	return env->NewStringUTF(v);
+}
+
 
 

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.h
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.h
@@ -239,7 +239,16 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
   (JNIEnv *, jobject, jobject, jobject);
 
+/*
+ * Class:     io_sqooba_traildb_TrailDBNative
+ * Method:    eventGetItemValue
+ * Signature: (Ljava/nio/ByteBuffer;ILjava/nio/ByteBuffer;)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_eventGetItemValue
+  (JNIEnv *, jobject, jobject, jint, jobject, jobject);
+
 #ifdef __cplusplus
 }
 #endif
 #endif
+


### PR DESCRIPTION
Instead of extracting each item of an event, copying it to a temporary array and then set this array as a field of the corresponding TrailDBEvent, just pass to the TrailDBEvent a handle to this array. We can then access items in the array by using this handle in JNI.