### PR TITLE
Remove bytebuffer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,8 +214,7 @@
 						<compilerStartOption>-Wall</compilerStartOption>
 						<compilerStartOption>-Werror</compilerStartOption>
 						<compilerStartOption>-fpic</compilerStartOption>
-						<compilerStartOption>-O0</compilerStartOption>
-						<compilerStartOption>-g</compilerStartOption>
+						<compilerStartOption>-Ofast</compilerStartOption>
 					</compilerStartOptions>
 
 					<linkerOutputDirectory>target</linkerOutputDirectory>

--- a/src/main/java/io/sqooba/traildb/TrailDBEvent.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBEvent.java
@@ -1,6 +1,5 @@
 package io.sqooba.traildb;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 /**
@@ -65,17 +64,11 @@ public class TrailDBEvent {
      */
     public String getFieldValue(int index) {
         // Caching possibility here to avoid going back to JNI to decode items.
-        final ByteBuffer bb = ByteBuffer.allocate(8);
-        final String value = TrailDBNative.INSTANCE.eventGetItemValue(this.trailDB.db, index, bb, this);
+        final String value = TrailDBNative.INSTANCE.eventGetItemValue(this.trailDB.db, index, this);
         if (value == null) {
             throw new TrailDBException("Value not found.");
         }
-        final long value_length = bb.getLong(0);
-        if (value_length > Integer.MAX_VALUE) {
-            throw new TrailDBException(
-                    "Overflow, received a String value that is larger than the java String capacity.");
-        }
-        return value.substring(0, (int)value_length);
+        return value;
     }
 
     @Override

--- a/src/main/java/io/sqooba/traildb/TrailDBInterface.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBInterface.java
@@ -4,40 +4,40 @@ import java.nio.ByteBuffer;
 
 public interface TrailDBInterface {
 
-    public ByteBuffer consInit();
+    public long consInit();
 
-    public int consOpen(ByteBuffer cons, String root, String[] ofieldNames, long numOfields);
+    public int consOpen(long cons, String root, String[] ofieldNames, long numOfields);
 
-    public void consClose(ByteBuffer cons);
+    public void consClose(long cons);
 
-    public int consAdd(ByteBuffer cons, byte[] uuid, long timestamp, String[] values,
+    public int consAdd(long cons, byte[] uuid, long timestamp, String[] values,
             long[] valueLengths);
 
-    public int consAppend(ByteBuffer cons, ByteBuffer db);
+    public int consAppend(long cons, long db);
 
-    public int consFinalize(ByteBuffer cons);
+    public int consFinalize(long cons);
 
     // ========================================================================
     // Open a TrailDB and access metadata.
     // ========================================================================
 
-    public ByteBuffer init();
+    public long init();
 
-    public int open(ByteBuffer db, String root);
+    public int open(long db, String root);
 
-    public void close(ByteBuffer db);
+    public void close(long db);
 
-    public long numTrails(ByteBuffer db);
+    public long numTrails(long db);
 
-    public long numEvents(ByteBuffer db);
+    public long numEvents(long db);
 
-    public long numFields(ByteBuffer db);
+    public long numFields(long db);
 
-    public long minTimestamp(ByteBuffer db);
+    public long minTimestamp(long db);
 
-    public long maxTimestamp(ByteBuffer db);
+    public long maxTimestamp(long db);
 
-    public long version(ByteBuffer db);
+    public long version(long db);
 
     public String errorStr(int errcode);
 
@@ -45,37 +45,37 @@ public interface TrailDBInterface {
     // Working with items, fields and values.
     // ========================================================================
 
-    public long lexiconSize(ByteBuffer db, long field);
+    public long lexiconSize(long db, long field);
 
-    public int getField(ByteBuffer db, String fieldName, ByteBuffer field);
+    public int getField(long db, String fieldName, ByteBuffer field);
 
-    public String getFieldName(ByteBuffer db, long field);
+    public String getFieldName(long db, long field);
 
-    public long getItem(ByteBuffer db, long field, String value);
+    public long getItem(long db, long field, String value);
 
-    public String getValue(ByteBuffer db, long field, long val, ByteBuffer value_length);
+    public String getValue(long db, long field, long val, ByteBuffer value_length);
 
-    public String getItemValue(ByteBuffer db, long item, ByteBuffer value_length);
+    public String getItemValue(long db, long item, ByteBuffer value_length);
 
     // ========================================================================
     // Working with UUIDs.
     // ========================================================================
 
-    public ByteBuffer getUUID(ByteBuffer db, long traildId);
+    public ByteBuffer getUUID(long db, long traildId);
 
-    public int getTrailId(ByteBuffer db, byte[] uuid, ByteBuffer trailId);
+    public int getTrailId(long db, byte[] uuid, ByteBuffer trailId);
 
     // ========================================================================
     // Query events with cursors.
     // ========================================================================
 
-    public ByteBuffer cursorNew(ByteBuffer db); // A cursor is a void *.
+    public long cursorNew(long db); // A cursor is a void *.
 
-    public void cursorFree(ByteBuffer cursor);
+    public void cursorFree(long cursor);
 
-    public int getTrail(ByteBuffer cursor, long trailID);
+    public int getTrail(long cursor, long trailID);
 
-    public long getTrailLength(ByteBuffer cursor);
+    public long getTrailLength(long cursor);
 
-    public int cursorNext(ByteBuffer cursor, TrailDBEvent event);
+    public int cursorNext(long cursor, TrailDBEvent event);
 }

--- a/src/main/java/io/sqooba/traildb/TrailDBIterator.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBIterator.java
@@ -1,6 +1,5 @@
 package io.sqooba.traildb;
 
-import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -17,11 +16,11 @@ import java.util.NoSuchElementException;
  */
 public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
 
-    private ByteBuffer cursor;
+    private long cursor;
     private final TrailDB trailDB;
     private final long size;
 
-    protected TrailDBIterator(ByteBuffer cursor, TrailDB trailDB, int size) {
+    protected TrailDBIterator(long cursor, TrailDB trailDB, int size) {
         this.cursor = cursor;
         this.trailDB = trailDB;
         this.size = size;
@@ -29,9 +28,9 @@ public class TrailDBIterator implements Iterable<TrailDBEvent>, AutoCloseable {
 
     @Override
     public void close() {
-        if (this.cursor != null) {
+        if (this.cursor != -1) {
             TrailDBNative.INSTANCE.cursorFree(this.cursor);
-            this.cursor = null;
+            this.cursor = -1;
         }
     }
 

--- a/src/main/java/io/sqooba/traildb/TrailDBNative.java
+++ b/src/main/java/io/sqooba/traildb/TrailDBNative.java
@@ -100,57 +100,57 @@ public enum TrailDBNative implements TrailDBInterface {
     // ========================================================================
 
     /** tdb_cons *tdb_cons_init(void) */
-    private native ByteBuffer tdbConsInit();
+    private native long tdbConsInit();
 
     /** tdb_error tdb_cons_open(tdb_const *cons, const char *root, const char **ofield_names, uint64_t num_ofields) */
-    private native int tdbConsOpen(ByteBuffer cons, String root, String[] ofieldNames, long numOfields);
+    private native int tdbConsOpen(long cons, String root, String[] ofieldNames, long numOfields);
 
     /** void tdb_cons_close(tdb_cons *cons) */
-    private native void tdbConsClose(ByteBuffer cons);
+    private native void tdbConsClose(long cons);
 
     /**
      * tdb_error tdb_cons_add(tdb_cons *cons,const uint8_t uuid[16],const uint64_t timestamp,const char **values,const
      * uint64_t *value_lengths)
      */
-    private native int tdbConsAdd(ByteBuffer cons, byte[] uuid, long timestamp, String[] values,
+    private native int tdbConsAdd(long cons, byte[] uuid, long timestamp, String[] values,
             long[] valueLengths);
 
     /** tdb_error tdb_cons_append(tdb_cons *cons, const tdb *db) */
-    private native int tdbConsAppend(ByteBuffer cons, ByteBuffer db);
+    private native int tdbConsAppend(long cons, long db);
 
     /** tdb_error tdb_cons_finalize(tdb_cons *cons) */
-    private native int tdbConsFinalize(ByteBuffer cons);
+    private native int tdbConsFinalize(long cons);
 
     // ========================================================================
     // Open a TrailDB and access metadata.
     // ========================================================================
 
     /** tdb *tdb_init(void) */
-    private native ByteBuffer tdbInit();
+    private native long tdbInit();
 
     /** tdb_error tdb_open(tdb *tdb, const char *root) */
-    private native int tdbOpen(ByteBuffer tdb, String root);
+    private native int tdbOpen(long tdb, String root);
 
     /** void tdb_close(tdb *db) */
-    private native void tdbClose(ByteBuffer db);
+    private native void tdbClose(long db);
 
     /** uint64_t tdb_num_trails(const tdb *db) */
-    private native long tdbNumTrails(ByteBuffer db);
+    private native long tdbNumTrails(long db);
 
     /** uint64_t tdb_num_events(const tdb *db) */
-    private native long tdbNumEvents(ByteBuffer db);
+    private native long tdbNumEvents(long db);
 
     /** uint64_t tdb_num_fields(const tdb *db) */
-    private native long tdbNumFields(ByteBuffer db);
+    private native long tdbNumFields(long db);
 
     /** uint64_t tdb_min_timestamp(const tdb *db) */
-    private native long tdbMinTimestamp(ByteBuffer db);
+    private native long tdbMinTimestamp(long db);
 
     /** uint64_t tdb_max_timestamp(const tdb *db) */
-    private native long tdbMaxTimestamp(ByteBuffer db);
+    private native long tdbMaxTimestamp(long db);
 
     /** uint64_t tdb_version(const tdb *db) */
-    private native long tdbVersion(ByteBuffer db);
+    private native long tdbVersion(long db);
 
     /** const char *tdb_error_str(tdb_error errcode) */
     private native String tdbErrorStr(int errcode);
@@ -160,132 +160,136 @@ public enum TrailDBNative implements TrailDBInterface {
     // ========================================================================
 
     /** uint64_t tdb_lexicon_size(const tdb *db, tdb_field field) */
-    private native long tdbLexiconSize(ByteBuffer db, long field); // tdb_field is a C uint32_t, ID of the field.
+    private native long tdbLexiconSize(long db, long field); // tdb_field is a C uint32_t, ID of the field.
 
     /** tdb_error tdb_get_field(tdb *db, const char *field_name, tdb_field *field) */
-    private native int tdbGetField(ByteBuffer db, String fieldName, ByteBuffer field);
+    private native int tdbGetField(long db, String fieldName, ByteBuffer field);
 
     /** const char *tdb_get_field_name(tdb *db, tdb_field field) */
-    private native String tdbGetFieldName(ByteBuffer db, long field);
+    private native String tdbGetFieldName(long db, long field);
 
     /** tdb_item tdb_get_item(tdb *db, tdb_field field, const char *value, uint64_t value_length) */
-    private native long tdbGetItem(ByteBuffer db, long field, String value);
+    private native long tdbGetItem(long db, long field, String value);
 
     /** const char *tdb_get_value(tdb *db, tdb_field field, tdb_val val, uint64_t *value_length) */
     // TODO WARNING be extremely careful here with val(uint64_t)
-    private native String tdbGetValue(ByteBuffer db, long field, long val, ByteBuffer value_length);
+    private native String tdbGetValue(long db, long field, long val, ByteBuffer value_length);
 
     /** const char *tdb_get_item_value(tdb *db, tdb_item item, uint64_t *value_length) */
-    private native String tdbGetItemValue(ByteBuffer db, long item, ByteBuffer value_length);
+    private native String tdbGetItemValue(long db, long item, ByteBuffer value_length);
 
     // ========================================================================
     // Working with UUIDs.
     // ========================================================================
 
     /** const uint8_t *tdb_get_uuid(const tdb *db, uint64_t trail_id) */
-    private native ByteBuffer tdbGetUUID(ByteBuffer db, long traildId);
+    private native ByteBuffer tdbGetUUID(long db, long traildId);
 
     /** tdb_error tdb_get_trail_id(const tdb *db, const uint8_t uuid[16], uint64_t *trail_id) */
-    private native int tdbGetTrailId(ByteBuffer db, byte[] uuid, ByteBuffer trailId);
+    private native int tdbGetTrailId(long db, byte[] uuid, ByteBuffer trailId);
 
     // ========================================================================
     // Query events with cursors.
     // ========================================================================
 
     /** tdb_cursor *tdb_cursor_new(const tdb *db) */
-    private native ByteBuffer tdbCursorNew(ByteBuffer db); // A cursor is a void *.
+    private native long tdbCursorNew(long db); // A cursor is a void *.
 
     /** void tdb_cursor_free(tdb_cursor *cursor) */
-    private native void tdbCursorFree(ByteBuffer cursor);
+    private native void tdbCursorFree(long cursor);
 
     /** tdb_error tdb_get_trail(tdb_cursor *cursor, uint64_t trail_id) */
-    private native int tdbGetTrail(ByteBuffer cursor, long trailID);
+    private native int tdbGetTrail(long cursor, long trailID);
 
     /** uint64_t tdb_get_trail_length(tdb_cursor *cursor) */
-    private native long tdbGetTrailLength(ByteBuffer cursor);
+    private native long tdbGetTrailLength(long cursor);
 
-    /** const tdb_event *tdb_cursor_next(tdb_cursor *cursor) */
-    private native int tdbCursorNext(ByteBuffer cursor, TrailDBEvent event);
+    /**
+     * const tdb_event *tdb_cursor_next(tdb_cursor *cursor)
+     *
+     * @param event
+     */
+    private native int tdbCursorNext(long cursor, TrailDBEvent event);
 
     // ========================================================================
     // Custom.
     // ========================================================================
 
-    public native String eventGetItemValue(ByteBuffer db, int index, ByteBuffer value_length, TrailDBEvent event);
+    public native String eventGetItemValue(long db, int index, TrailDBEvent event);
 
     @Override
-    public ByteBuffer consInit() {
+    public long consInit() {
         return tdbConsInit();
     }
 
     @Override
-    public int consOpen(ByteBuffer cons, String root, String[] ofieldNames, long numOfields) {
+    public int consOpen(long cons, String root, String[] ofieldNames, long numOfields) {
         return tdbConsOpen(cons, root, ofieldNames, numOfields);
     }
 
     @Override
-    public void consClose(ByteBuffer cons) {
+    public void consClose(long cons) {
         tdbConsClose(cons);
 
     }
 
     @Override
-    public int consAdd(ByteBuffer cons, byte[] uuid, long timestamp, String[] values, long[] valueLengths) {
+    public int consAdd(long cons, byte[] uuid, long timestamp, String[] values, long[] valueLengths) {
         return tdbConsAdd(cons, uuid, timestamp, values, valueLengths);
     }
 
     @Override
-    public int consAppend(ByteBuffer cons, ByteBuffer db) {
+    public int consAppend(long cons, long db) {
         return tdbConsAppend(cons, db);
     }
 
     @Override
-    public int consFinalize(ByteBuffer cons) {
+    public int consFinalize(long cons) {
         return tdbConsFinalize(cons);
     }
 
     @Override
-    public ByteBuffer init() {
+    public long init() {
         return tdbInit();
     }
 
     @Override
-    public int open(ByteBuffer tdb, String root) {
-        return tdbOpen(tdb, root);
+    public int open(long db, String root) {
+        return tdbOpen(db, root);
     }
 
     @Override
-    public void close(ByteBuffer db) {
+    public void close(long db) {
         tdbClose(db);
     }
 
     @Override
-    public long numTrails(ByteBuffer db) {
+    public long numTrails(long db) {
         return tdbNumTrails(db);
     }
 
     @Override
-    public long numEvents(ByteBuffer db) {
+    public long numEvents(long db) {
         return tdbNumEvents(db);
     }
 
     @Override
-    public long numFields(ByteBuffer db) {
+    public long numFields(long db) {
         return tdbNumFields(db);
     }
 
     @Override
-    public long minTimestamp(ByteBuffer db) {
+    public long minTimestamp(long db) {
         return tdbMinTimestamp(db);
     }
 
     @Override
-    public long maxTimestamp(ByteBuffer db) {
+    public long maxTimestamp(long db) {
         return tdbMaxTimestamp(db);
     }
 
     @Override
-    public long version(ByteBuffer db) {
+    public long version(long db) {
         return tdbVersion(db);
     }
 
@@ -295,67 +299,67 @@ public enum TrailDBNative implements TrailDBInterface {
     }
 
     @Override
-    public long lexiconSize(ByteBuffer db, long field) {
+    public long lexiconSize(long db, long field) {
         return tdbLexiconSize(db, field);
     }
 
     @Override
-    public int getField(ByteBuffer db, String fieldName, ByteBuffer field) {
+    public int getField(long db, String fieldName, ByteBuffer field) {
         return tdbGetField(db, fieldName, field);
     }
 
     @Override
-    public String getFieldName(ByteBuffer db, long field) {
+    public String getFieldName(long db, long field) {
         return tdbGetFieldName(db, field);
     }
 
     @Override
-    public long getItem(ByteBuffer db, long field, String value) {
+    public long getItem(long db, long field, String value) {
         return tdbGetItem(db, field, value);
     }
 
     @Override
-    public String getValue(ByteBuffer db, long field, long val, ByteBuffer value_length) {
+    public String getValue(long db, long field, long val, ByteBuffer value_length) {
         return tdbGetValue(db, field, val, value_length);
     }
 
     @Override
-    public String getItemValue(ByteBuffer db, long item, ByteBuffer value_length) {
+    public String getItemValue(long db, long item, ByteBuffer value_length) {
         return tdbGetItemValue(db, item, value_length);
     }
 
     @Override
-    public ByteBuffer getUUID(ByteBuffer db, long traildId) {
+    public ByteBuffer getUUID(long db, long traildId) {
         return tdbGetUUID(db, traildId);
     }
 
     @Override
-    public int getTrailId(ByteBuffer db, byte[] uuid, ByteBuffer trailId) {
+    public int getTrailId(long db, byte[] uuid, ByteBuffer trailId) {
         return tdbGetTrailId(db, uuid, trailId);
     }
 
     @Override
-    public ByteBuffer cursorNew(ByteBuffer db) {
+    public long cursorNew(long db) {
         return tdbCursorNew(db);
     }
 
     @Override
-    public void cursorFree(ByteBuffer cursor) {
+    public void cursorFree(long cursor) {
         tdbCursorFree(cursor);
     }
 
     @Override
-    public int getTrail(ByteBuffer cursor, long trailID) {
+    public int getTrail(long cursor, long trailID) {
         return tdbGetTrail(cursor, trailID);
     }
 
     @Override
-    public long getTrailLength(ByteBuffer cursor) {
+    public long getTrailLength(long cursor) {
         return tdbGetTrailLength(cursor);
     }
 
     @Override
-    public int cursorNext(ByteBuffer cursor, TrailDBEvent event) {
+    public int cursorNext(long cursor, TrailDBEvent event) {
         return tdbCursorNext(cursor, event);
     }
 }

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
@@ -46,20 +46,23 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
     }
 }
 
-JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsInit
+JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsInit
   (JNIEnv *env, jobject thisObject) 
 {
 
 	void *cons = tdb_cons_init();
-	jobject bb = env->NewDirectByteBuffer((void*) cons, sizeof(void *));
-    return bb;
+	if(!cons) {
+		return -1;
+	}
+
+    return (long)cons;
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsOpen
-  (JNIEnv *env, jobject thisObject, jobject consj, jstring rootj, jobjectArray fieldNamesj, jlong numOfieldsj)
+  (JNIEnv *env, jobject thisObject, jlong consj, jstring rootj, jobjectArray fieldNamesj, jlong numOfieldsj)
 {
 	// Convert arguments.
-    tdb_cons *cons = (tdb_cons*) env->GetDirectBufferAddress(consj);
+    tdb_cons *cons = (tdb_cons*) consj;
     const char *root = env->GetStringUTFChars(rootj, 0);
 
 	jsize length = env->GetArrayLength(fieldNamesj); // Should be equal to numOfields
@@ -78,22 +81,22 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsOpen
 }
 
 JNIEXPORT void JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsClose
-  (JNIEnv *env, jobject thisObject, jobject consj) 
+  (JNIEnv *env, jobject thisObject, jlong consj) 
 {
 
 	// Convert arguments.
-	tdb_cons *cons = (tdb_cons*) env->GetDirectBufferAddress(consj);
+	tdb_cons *cons = (tdb_cons*) consj;
 
 	// Call lib.
 	tdb_cons_close(cons);
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsAdd
-	(JNIEnv *env, jobject thisObject, jobject consj, jbyteArray uuidj, jlong timestampj, jobjectArray valuesj, jlongArray valuesLengths) 
+	(JNIEnv *env, jobject thisObject, jlong consj, jbyteArray uuidj, jlong timestampj, jobjectArray valuesj, jlongArray valuesLengths) 
 {
 
 	// Convert arguments.
-	tdb_cons *cons = (tdb_cons*) env->GetDirectBufferAddress(consj);
+	tdb_cons *cons = (tdb_cons*) consj;
 
 	jbyte* dataPtr = env->GetByteArrayElements(uuidj, NULL);
 	const uint8_t *uuid = (const uint8_t*)dataPtr;
@@ -115,12 +118,12 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsAdd
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsAppend
-  (JNIEnv *env, jobject thisObject, jobject consj, jobject tdbj) 
+  (JNIEnv *env, jobject thisObject, jlong consj, jlong tdbj) 
 {
 
 	// Convert arguments.
-	tdb_cons *cons = (tdb_cons*) env->GetDirectBufferAddress(consj);
-	tdb *db = (tdb*) env->GetDirectBufferAddress(tdbj);
+	tdb_cons *cons = (tdb_cons*) consj;
+	tdb *db = (tdb*) tdbj;
 
 	// Call lib.
 	return tdb_cons_append(cons, db);
@@ -128,33 +131,37 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsAppend
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsFinalize
-  (JNIEnv *env, jobject thisObject, jobject consj) 
+  (JNIEnv *env, jobject thisObject, jlong consj) 
 {
 
 	// Convert arguments.
-	tdb_cons *cons = (tdb_cons*) env->GetDirectBufferAddress(consj);
+	tdb_cons *cons = (tdb_cons*) consj;
 
 	// Call lib.
 	return tdb_cons_finalize(cons);
 
 }
 
-JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbInit
+JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbInit
   (JNIEnv *env, jobject thisObject) 
 {
 
 	void *tdb = tdb_init();
-	jobject byteBuffer = env->NewDirectByteBuffer((void*) tdb, sizeof(&tdb));
-    return byteBuffer; 
+
+	if(!tdb) {
+		return -1;
+	}
+
+    return (long)tdb; 
 
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbOpen
-  (JNIEnv *env, jobject thisObject, jobject jtdb, jstring jroot) 
+  (JNIEnv *env, jobject thisObject, jlong jtdb, jstring jroot) 
 {
 
 	// Convert arguments.
-    tdb *db = (tdb*) env->GetDirectBufferAddress(jtdb);
+    tdb *db = (tdb*) jtdb;
     const char *root = env->GetStringUTFChars(jroot, 0);
 
 	// Call lib.
@@ -163,23 +170,22 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbOpen
 }
 
 JNIEXPORT void JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbClose
-  (JNIEnv *env, jobject thisObject, jobject jdb) 
+  (JNIEnv *env, jobject thisObject, jlong jdb) 
 {
 
 	// Convert arguments.
-	tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	tdb *db = (tdb*)jdb;
 
 	// Call lib.
 	tdb_close(db);
-
 }
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumTrails
-  (JNIEnv *env, jobject thisObject, jobject jdb) 
+  (JNIEnv *env, jobject thisObject, jlong jdb) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	
 	// Call lib.
 	return (jlong)tdb_num_trails(db);
@@ -187,11 +193,11 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumTrails
 }
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumEvents
-  (JNIEnv *env, jobject thisObject, jobject jdb) 
+  (JNIEnv *env, jobject thisObject, jlong jdb) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	
 	// Call lib.
 	return (jlong)tdb_num_events(db);
@@ -200,11 +206,11 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumEvents
 
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumFields
-  (JNIEnv *env, jobject thisObject, jobject jdb) 
+  (JNIEnv *env, jobject thisObject, jlong jdb) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	
 	// Call lib.
 	return (jlong)tdb_num_fields(db);
@@ -213,11 +219,11 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumFields
 
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbMinTimestamp
-  (JNIEnv *env, jobject thisObject, jobject jdb) 
+  (JNIEnv *env, jobject thisObject, jlong jdb) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	
 	// Call lib.
 	return (jlong)tdb_min_timestamp(db);
@@ -226,11 +232,11 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbMinTimestamp
 
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbMaxTimestamp
-  (JNIEnv *env, jobject thisObject, jobject jdb) 
+  (JNIEnv *env, jobject thisObject, jlong jdb) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	
 	// Call lib.
 	return (jlong)tdb_max_timestamp(db);
@@ -239,11 +245,11 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbMaxTimestamp
 
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbVersion
-  (JNIEnv *env, jobject thisObject, jobject jdb) 
+  (JNIEnv *env, jobject thisObject, jlong jdb) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	
 	// Call lib.
 	return (jlong)tdb_version(db);
@@ -266,11 +272,11 @@ JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbErrorStr
 }
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbLexiconSize
-  (JNIEnv *env, jobject thisObject, jobject jdb, jlong jfield) 
+  (JNIEnv *env, jobject thisObject, jlong jdb, jlong jfield) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	int nativeInt = (int)jfield;
 
 	// Call lib.
@@ -279,11 +285,11 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbLexiconSize
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetField
-  (JNIEnv *env, jobject thisObject, jobject jdb, jstring jfieldName, jobject jfield) 
+  (JNIEnv *env, jobject thisObject, jlong jdb, jstring jfieldName, jobject jfield) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	const char *field_name = env->GetStringUTFChars(jfieldName, 0);
 	//tdb_field *field= (tdb_field*) env->GetDirectBufferAddress(jfield);
 	tdb_field *field = (tdb_field*)malloc(sizeof(tdb_field));
@@ -304,11 +310,11 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetField
 }
 
 JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetFieldName
-  (JNIEnv *env, jobject thisObject, jobject jdb, jlong jfield) 
+  (JNIEnv *env, jobject thisObject, jlong jdb, jlong jfield) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	int nativeField = (int)jfield;
 
 	// Call lib.
@@ -319,11 +325,11 @@ JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetFieldName
 }
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetItem
-  (JNIEnv *env, jobject thisObject, jobject jdb, jlong jfield, jstring jvalue) 
+  (JNIEnv *env, jobject thisObject, jlong jdb, jlong jfield, jstring jvalue) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	int field = (int)jfield;
 	const char *value = env->GetStringUTFChars(jvalue, 0);
 
@@ -333,11 +339,11 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetItem
 }
 
 JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetValue
-  (JNIEnv *env, jobject thisObject, jobject jdb, jlong jfield, jlong jval, jobject jvalueLength)
+  (JNIEnv *env, jobject thisObject, jlong jdb, jlong jfield, jlong jval, jobject jvalueLength)
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	uint32_t field = (uint32_t)jfield;
 	uint64_t val = (uint64_t)jval;
 	uint64_t *value_length = (uint64_t*)malloc(sizeof(uint64_t));
@@ -358,11 +364,11 @@ JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetValue
 }
 
 JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetItemValue
-  (JNIEnv *env, jobject thisObject, jobject jdb, jlong jitem, jobject jvalueLength)
+  (JNIEnv *env, jobject thisObject, jlong jdb, jlong jitem, jobject jvalueLength)
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	uint64_t item = (uint64_t)jitem;
 	uint64_t *value_length = (uint64_t*)malloc(sizeof(uint64_t));
 
@@ -383,11 +389,11 @@ JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetItemValue
 }
 
 JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetUUID
-  (JNIEnv *env, jobject thisObject, jobject jdb, jlong jtrailID) 
+  (JNIEnv *env, jobject thisObject, jlong jdb, jlong jtrailID) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	uint64_t trail_id = (uint64_t) jtrailID;
 
 	// Call lib.
@@ -398,11 +404,11 @@ JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetUUID
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailId
-  (JNIEnv *env, jobject thisObject, jobject jdb, jbyteArray juuid, jobject jtraildID) 
+  (JNIEnv *env, jobject thisObject, jlong jdb, jbyteArray juuid, jobject jtraildID) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 
 	jbyte* dataPtr = env->GetByteArrayElements(juuid, NULL);
 	const uint8_t *uuid = (const uint8_t*)dataPtr;
@@ -422,26 +428,29 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailId
 	return err;
 }
 
-JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNew
-  (JNIEnv *env, jobject thisObject, jobject jdb) 
+JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNew
+  (JNIEnv *env, jobject thisObject, jlong jdb) 
 {
 
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 
 	// Call lib.
 	void *cursor = tdb_cursor_new(db);
-	jobject cursorByteBuffer = env->NewDirectByteBuffer((void*) cursor, sizeof(void *));
+	
+	if(!cursor) {
+		return -1;
+	}
     
-	return cursorByteBuffer;
+	return (long)cursor;
 }
 
 JNIEXPORT void JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorFree
-  (JNIEnv *env, jobject thisObject, jobject jcursor) 
+  (JNIEnv *env, jobject thisObject, jlong jcursor) 
 {
 
 	// Convert arguments.
-	tdb_cursor *cursor = (tdb_cursor*) env->GetDirectBufferAddress(jcursor);
+	tdb_cursor *cursor = (tdb_cursor*)jcursor;
 
 	// Call lib.
 	tdb_cursor_free(cursor);
@@ -449,11 +458,11 @@ JNIEXPORT void JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorFree
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrail
-  (JNIEnv *env, jobject thisObject, jobject jcursor, jlong jtrailID) 
+  (JNIEnv *env, jobject thisObject, jlong jcursor, jlong jtrailID) 
 {
 
 	// Convert arguments.
-	tdb_cursor *cursor = (tdb_cursor*) env->GetDirectBufferAddress(jcursor);
+	tdb_cursor *cursor = (tdb_cursor*)jcursor;
 	uint64_t trail_id = (uint64_t) jtrailID;	
 
 	// Call lib.
@@ -461,22 +470,22 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrail
 }
 
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
-  (JNIEnv *env, jobject thisObject, jobject jcursor) 
+  (JNIEnv *env, jobject thisObject, jlong jcursor) 
 {
 
 	// Convert arguments.
-	tdb_cursor *cursor = (tdb_cursor*) env->GetDirectBufferAddress(jcursor);
+	tdb_cursor *cursor = (tdb_cursor*)jcursor;
 
 	// Call lib.
 	return (jlong) tdb_get_trail_length(cursor);
 }
 
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
-  (JNIEnv *env, jobject thisObject, jobject jcursor, jobject jevent)
+  (JNIEnv *env, jobject thisObject, jlong jcursor, jobject jevent)
 {
 
 	// Convert arguments.
-	tdb_cursor *cursor = (tdb_cursor*) env->GetDirectBufferAddress(jcursor);
+	tdb_cursor *cursor = (tdb_cursor*)jcursor;
 
 	// Call lib.
 	const tdb_event *event;
@@ -496,15 +505,13 @@ JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
 }
 
 JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_eventGetItemValue
-  (JNIEnv *env, jobject thisObject, jobject jdb, jint jindex, jobject jvalueLength, jobject jevent) 
+  (JNIEnv *env, jobject thisObject, jlong jdb, jint jindex, jobject jevent) 
 {
 	
 	// Convert arguments.
-	const tdb *db = (tdb*) env->GetDirectBufferAddress(jdb);
+	const tdb *db = (tdb*)jdb;
 	uint64_t value_length;
 
-	jclass jc = env->GetObjectClass(jvalueLength);
-	jmethodID mid = env->GetMethodID(jc, "putLong","(J)Ljava/nio/ByteBuffer;");
 
 	// Get the items pointer.
 	const tdb_item *items;
@@ -513,10 +520,12 @@ JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_eventGetItemValue
 	// Call lib.
 	const char* v = tdb_get_item_value(db, items[jindex], &value_length);
 
-	// Store to the buffer the what has been put in the pointer.
-	env->CallObjectMethod(jvalueLength, mid, value_length);
+	// Create the null-terminated String.
+	char buffer[value_length];
+	memcpy(buffer, &v[0], value_length);
+	buffer[value_length] = '\0';
 
-	return env->NewStringUTF(v);
+	return env->NewStringUTF(buffer);
 }
 
 

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.cpp
@@ -436,7 +436,7 @@ JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNew
 	const tdb *db = (tdb*)jdb;
 
 	// Call lib.
-	void *cursor = tdb_cursor_new(db);
+	tdb_cursor *cursor = tdb_cursor_new(db);
 	
 	if(!cursor) {
 		return -1;

--- a/src/main/native/io_sqooba_traildb_TrailDBNative.h
+++ b/src/main/native/io_sqooba_traildb_TrailDBNative.h
@@ -10,122 +10,122 @@ extern "C" {
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbConsInit
- * Signature: ()Ljava/nio/ByteBuffer;
+ * Signature: ()J
  */
-JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsInit
+JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsInit
   (JNIEnv *, jobject);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbConsOpen
- * Signature: (Ljava/nio/ByteBuffer;Ljava/lang/String;[Ljava/lang/String;J)I
+ * Signature: (JLjava/lang/String;[Ljava/lang/String;J)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsOpen
-  (JNIEnv *, jobject, jobject, jstring, jobjectArray, jlong);
+  (JNIEnv *, jobject, jlong, jstring, jobjectArray, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbConsClose
- * Signature: (Ljava/nio/ByteBuffer;)V
+ * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsClose
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbConsAdd
- * Signature: (Ljava/nio/ByteBuffer;[BJ[Ljava/lang/String;[J)I
+ * Signature: (J[BJ[Ljava/lang/String;[J)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsAdd
-  (JNIEnv *, jobject, jobject, jbyteArray, jlong, jobjectArray, jlongArray);
+  (JNIEnv *, jobject, jlong, jbyteArray, jlong, jobjectArray, jlongArray);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbConsAppend
- * Signature: (Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)I
+ * Signature: (JJ)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsAppend
-  (JNIEnv *, jobject, jobject, jobject);
+  (JNIEnv *, jobject, jlong, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbConsFinalize
- * Signature: (Ljava/nio/ByteBuffer;)I
+ * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbConsFinalize
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbInit
- * Signature: ()Ljava/nio/ByteBuffer;
+ * Signature: ()J
  */
-JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbInit
+JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbInit
   (JNIEnv *, jobject);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbOpen
- * Signature: (Ljava/nio/ByteBuffer;Ljava/lang/String;)I
+ * Signature: (JLjava/lang/String;)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbOpen
-  (JNIEnv *, jobject, jobject, jstring);
+  (JNIEnv *, jobject, jlong, jstring);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbClose
- * Signature: (Ljava/nio/ByteBuffer;)V
+ * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbClose
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbNumTrails
- * Signature: (Ljava/nio/ByteBuffer;)J
+ * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumTrails
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbNumEvents
- * Signature: (Ljava/nio/ByteBuffer;)J
+ * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumEvents
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbNumFields
- * Signature: (Ljava/nio/ByteBuffer;)J
+ * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbNumFields
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbMinTimestamp
- * Signature: (Ljava/nio/ByteBuffer;)J
+ * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbMinTimestamp
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbMaxTimestamp
- * Signature: (Ljava/nio/ByteBuffer;)J
+ * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbMaxTimestamp
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbVersion
- * Signature: (Ljava/nio/ByteBuffer;)J
+ * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbVersion
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
@@ -138,114 +138,114 @@ JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbErrorStr
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbLexiconSize
- * Signature: (Ljava/nio/ByteBuffer;J)J
+ * Signature: (JJ)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbLexiconSize
-  (JNIEnv *, jobject, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetField
- * Signature: (Ljava/nio/ByteBuffer;Ljava/lang/String;Ljava/nio/ByteBuffer;)I
+ * Signature: (JLjava/lang/String;Ljava/nio/ByteBuffer;)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetField
-  (JNIEnv *, jobject, jobject, jstring, jobject);
+  (JNIEnv *, jobject, jlong, jstring, jobject);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetFieldName
- * Signature: (Ljava/nio/ByteBuffer;J)Ljava/lang/String;
+ * Signature: (JJ)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetFieldName
-  (JNIEnv *, jobject, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetItem
- * Signature: (Ljava/nio/ByteBuffer;JLjava/lang/String;)J
+ * Signature: (JJLjava/lang/String;)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetItem
-  (JNIEnv *, jobject, jobject, jlong, jstring);
+  (JNIEnv *, jobject, jlong, jlong, jstring);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetValue
- * Signature: (Ljava/nio/ByteBuffer;JJLjava/nio/ByteBuffer;)Ljava/lang/String;
+ * Signature: (JJJLjava/nio/ByteBuffer;)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetValue
-  (JNIEnv *, jobject, jobject, jlong, jlong, jobject);
+  (JNIEnv *, jobject, jlong, jlong, jlong, jobject);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetItemValue
- * Signature: (Ljava/nio/ByteBuffer;JLjava/nio/ByteBuffer;)Ljava/lang/String;
+ * Signature: (JJLjava/nio/ByteBuffer;)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetItemValue
-  (JNIEnv *, jobject, jobject, jlong, jobject);
+  (JNIEnv *, jobject, jlong, jlong, jobject);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetUUID
- * Signature: (Ljava/nio/ByteBuffer;J)Ljava/nio/ByteBuffer;
+ * Signature: (JJ)Ljava/nio/ByteBuffer;
  */
 JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetUUID
-  (JNIEnv *, jobject, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetTrailId
- * Signature: (Ljava/nio/ByteBuffer;[BLjava/nio/ByteBuffer;)I
+ * Signature: (J[BLjava/nio/ByteBuffer;)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailId
-  (JNIEnv *, jobject, jobject, jbyteArray, jobject);
+  (JNIEnv *, jobject, jlong, jbyteArray, jobject);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbCursorNew
- * Signature: (Ljava/nio/ByteBuffer;)Ljava/nio/ByteBuffer;
+ * Signature: (J)J
  */
-JNIEXPORT jobject JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNew
-  (JNIEnv *, jobject, jobject);
+JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNew
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbCursorFree
- * Signature: (Ljava/nio/ByteBuffer;)V
+ * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorFree
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetTrail
- * Signature: (Ljava/nio/ByteBuffer;J)I
+ * Signature: (JJ)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrail
-  (JNIEnv *, jobject, jobject, jlong);
+  (JNIEnv *, jobject, jlong, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbGetTrailLength
- * Signature: (Ljava/nio/ByteBuffer;)J
+ * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbGetTrailLength
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jlong);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    tdbCursorNext
- * Signature: (Ljava/nio/ByteBuffer;Lio/sqooba/traildb/TrailDBEvent;)I
+ * Signature: (JLio/sqooba/traildb/TrailDBEvent;)I
  */
 JNIEXPORT jint JNICALL Java_io_sqooba_traildb_TrailDBNative_tdbCursorNext
-  (JNIEnv *, jobject, jobject, jobject);
+  (JNIEnv *, jobject, jlong, jobject);
 
 /*
  * Class:     io_sqooba_traildb_TrailDBNative
  * Method:    eventGetItemValue
- * Signature: (Ljava/nio/ByteBuffer;ILjava/nio/ByteBuffer;)Ljava/lang/String;
+ * Signature: (JILio/sqooba/traildb/TrailDBEvent;)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_io_sqooba_traildb_TrailDBNative_eventGetItemValue
-  (JNIEnv *, jobject, jobject, jint, jobject, jobject);
+  (JNIEnv *, jobject, jlong, jint, jobject);
 
 #ifdef __cplusplus
 }

--- a/src/test/java/io/sqooba/traildb/test/TrailDBBuilderFailureTest.java
+++ b/src/test/java/io/sqooba/traildb/test/TrailDBBuilderFailureTest.java
@@ -2,7 +2,6 @@ package io.sqooba.traildb.test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -17,8 +16,8 @@ import mockit.Expectations;
 
 public class TrailDBBuilderFailureTest {
 
-    private String path = "testdb";
-    private String cookie = "12345678123456781234567812345678";
+    private final String path = "testdb";
+    private final String cookie = "12345678123456781234567812345678";
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -27,7 +26,7 @@ public class TrailDBBuilderFailureTest {
     public void tearDown() throws IOException {
 
         // Clear the TrailDB files/directories created for the tests.
-        File f = new File(this.path + ".tdb");
+        final File f = new File(this.path + ".tdb");
         if (f.exists() && !f.isDirectory()) {
             f.delete();
         }
@@ -45,7 +44,7 @@ public class TrailDBBuilderFailureTest {
 
             {
                 traildbj.consInit();
-                this.result = null;
+                this.result = -1;
             }
         };
         new TrailDB.TrailDBBuilder(this.path, new String[] { "field1", "field2" });
@@ -61,7 +60,7 @@ public class TrailDBBuilderFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.consOpen((ByteBuffer)this.any, this.anyString, (String[])this.any, this.anyLong);
+                traildbj.consOpen(this.anyLong, this.anyString, (String[])this.any, this.anyLong);
                 this.result = -1;
             }
         };
@@ -78,7 +77,7 @@ public class TrailDBBuilderFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.consAdd((ByteBuffer)this.any, (byte[])this.any, this.anyLong, (String[])this.any,
+                traildbj.consAdd(this.anyLong, (byte[])this.any, this.anyLong, (String[])this.any,
                         (long[])this.any);
                 this.result = -1;
             }
@@ -97,11 +96,11 @@ public class TrailDBBuilderFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.consAppend((ByteBuffer)this.any, (ByteBuffer)this.any);
+                traildbj.consAppend(this.anyLong, this.anyLong);
                 this.result = -1;
             }
         };
-        TrailDB db = new TrailDB.TrailDBBuilder(this.path, new String[] { "field1", "field2" }).build();
+        final TrailDB db = new TrailDB.TrailDBBuilder(this.path, new String[] { "field1", "field2" }).build();
         new TrailDB.TrailDBBuilder(this.path, new String[] { "field1", "field2" }).append(db);
     }
 
@@ -115,7 +114,7 @@ public class TrailDBBuilderFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.consFinalize((ByteBuffer)this.any);
+                traildbj.consFinalize(this.anyLong);
                 this.result = -1;
             }
         };

--- a/src/test/java/io/sqooba/traildb/test/TrailDBFailureTest.java
+++ b/src/test/java/io/sqooba/traildb/test/TrailDBFailureTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -69,7 +68,7 @@ public class TrailDBFailureTest {
 
             {
                 traildbj.init();
-                this.result = null;
+                this.result = -1;
             }
         };
         try (TrailDB db = new TrailDB(this.path)) {
@@ -86,7 +85,7 @@ public class TrailDBFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.open((ByteBuffer)this.any, this.anyString);
+                traildbj.open(this.anyLong, this.anyString);
                 this.result = -1;
             }
         };
@@ -101,7 +100,7 @@ public class TrailDBFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.minTimestamp((ByteBuffer)this.any);
+                traildbj.minTimestamp(this.anyLong);
                 this.result = -1;
             }
         };
@@ -116,7 +115,7 @@ public class TrailDBFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.maxTimestamp((ByteBuffer)this.any);
+                traildbj.maxTimestamp(this.anyLong);
                 this.result = -1;
             }
         };
@@ -131,7 +130,7 @@ public class TrailDBFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.version((ByteBuffer)this.any);
+                traildbj.version(this.anyLong);
                 this.result = -1;
             }
         };
@@ -147,7 +146,7 @@ public class TrailDBFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.getItem((ByteBuffer)this.any, this.anyLong, this.anyString);
+                traildbj.getItem(this.anyLong, this.anyLong, this.anyString);
                 this.result = -1;
             }
         };
@@ -166,7 +165,7 @@ public class TrailDBFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.getUUID((ByteBuffer)this.any, this.anyLong);
+                traildbj.getUUID(this.anyLong, this.anyLong);
                 this.result = null;
             }
         };
@@ -182,8 +181,8 @@ public class TrailDBFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.cursorNew((ByteBuffer)this.any);
-                this.result = null;
+                traildbj.cursorNew(this.anyLong);
+                this.result = -1;
             }
         };
         this.db.trail(0);
@@ -198,7 +197,7 @@ public class TrailDBFailureTest {
         new Expectations(traildbj) {
 
             {
-                traildbj.getTrail((ByteBuffer)this.any, this.anyLong);
+                traildbj.getTrail(this.anyLong, this.anyLong);
                 this.result = -1;
             }
         };

--- a/src/test/java/io/sqooba/traildb/test/TrailDBIteratorTest.java
+++ b/src/test/java/io/sqooba/traildb/test/TrailDBIteratorTest.java
@@ -1,7 +1,6 @@
 package io.sqooba.traildb.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,8 +18,8 @@ import mockit.Deencapsulation;
 public class TrailDBIteratorTest {
 
     private TrailDB db;
-    private String path = "testdb";
-    private String cookie = "12345678123456781234567812345678";
+    private final String path = "testdb";
+    private final String cookie = "12345678123456781234567812345678";
 
     @Before
     public void setUp() {
@@ -33,7 +32,7 @@ public class TrailDBIteratorTest {
     public void tearDown() throws IOException {
 
         // Clear the TrailDB files/directories created for the tests.
-        File f = new File(this.path + ".tdb");
+        final File f = new File(this.path + ".tdb");
         if (f.exists() && !f.isDirectory()) {
             f.delete();
         }
@@ -43,34 +42,34 @@ public class TrailDBIteratorTest {
     @Test
     public void closeWithNullCursorField() {
 
-        TrailDBIterator cursor = this.db.trail(0);
+        final TrailDBIterator cursor = this.db.trail(0);
 
-        Deencapsulation.setField(cursor, "cursor", null);
+        Deencapsulation.setField(cursor, "cursor", -1);
         cursor.close();
     }
 
     @Test
     public void getTrailLengthShouldReturnCorrectRemainingEvents() {
-        TrailDBIterator cursor = this.db.trail(0);
+        final TrailDBIterator cursor = this.db.trail(0);
         assertEquals(1, TrailDBNative.INSTANCE.getTrailLength(Deencapsulation.getField(cursor, "cursor")));
         cursor.close();
     }
 
     @Test
     public void closeShouldFreeCursor() {
-        TrailDBIterator cursor = this.db.trail(0);
+        final TrailDBIterator cursor = this.db.trail(0);
         cursor.close();
-        assertNull(Deencapsulation.getField(cursor, "cursor"));
+        assertEquals(-1, (long)Deencapsulation.getField(cursor, "cursor"));
     }
 
     @Test
     public void iteratorsShoudNotInterfere() {
-        TrailDB db = new TrailDB.TrailDBBuilder(this.path, new String[] { "field1", "field2" })
+        final TrailDB db = new TrailDB.TrailDBBuilder(this.path, new String[] { "field1", "field2" })
                 .add(this.cookie, 120, new String[] { "a", "hinata" })
                 .build();
 
-        TrailDBIterator trail1 = db.trail(0);
-        TrailDBIterator trail2 = db.trail(0);
+        final TrailDBIterator trail1 = db.trail(0);
+        final TrailDBIterator trail2 = db.trail(0);
 
         assertEquals(trail1.iterator().next().toString(), trail2.iterator().next().toString());
     }

--- a/src/test/java/io/sqooba/traildb/test/TrailDBTest.java
+++ b/src/test/java/io/sqooba/traildb/test/TrailDBTest.java
@@ -1,7 +1,6 @@
 package io.sqooba.traildb.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,9 +25,9 @@ import mockit.Deencapsulation;
 public class TrailDBTest {
 
     private TrailDB db;
-    private String path = "testdb";
-    private String cookie = "12345678123456781234567812345678";
-    private String otherCookie = "12121212121212121212121212121212";
+    private final String path = "testdb";
+    private final String cookie = "12345678123456781234567812345678";
+    private final String otherCookie = "12121212121212121212121212121212";
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -47,10 +46,10 @@ public class TrailDBTest {
 
     @Test
     public void trailsShouldContainCorrectTrailUUIDs() {
-        Map<String, TrailDBIterator> map = this.db.trails();
+        final Map<String, TrailDBIterator> map = this.db.trails();
         assertEquals(2, map.size());
 
-        Iterator<Map.Entry<String, TrailDBIterator>> it = map.entrySet().iterator();
+        final Iterator<Map.Entry<String, TrailDBIterator>> it = map.entrySet().iterator();
         assertEquals(this.otherCookie, it.next().getKey());
         assertEquals(this.cookie, it.next().getKey());
     }
@@ -59,14 +58,14 @@ public class TrailDBTest {
     public void trailShouldContainCorrectNumberOfTrailDBEvents() {
         TrailDBIterator trail = this.db.trail(0);
         int count = 0;
-        for(TrailDBEvent TrailDBEvent : trail) {
+        for(final TrailDBEvent TrailDBEvent : trail) {
             count++;
         }
         assertEquals(2, count);
 
         trail = this.db.trail(1);
         count = 0;
-        for(TrailDBEvent TrailDBEvent : trail) {
+        for(final TrailDBEvent TrailDBEvent : trail) {
             count++;
         }
         assertEquals(2, count);
@@ -74,9 +73,9 @@ public class TrailDBTest {
 
     @Test
     public void trailShouldContainCorrectTrailDBEvents() {
-        TrailDBIterator trail = this.db.trail(0);
-        TrailDBEvent e = trail.iterator().next();
-        String[] fieldsNames = e.getFieldNames();
+        final TrailDBIterator trail = this.db.trail(0);
+        final TrailDBEvent e = trail.iterator().next();
+        final String[] fieldsNames = e.getFieldNames();
 
         assertEquals(122, e.getTimestamp());
         assertEquals(2, e.getNumItems());
@@ -88,7 +87,7 @@ public class TrailDBTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void trailRemoveShouldThrow() {
-        TrailDBIterator trail = this.db.trail(0);
+        final TrailDBIterator trail = this.db.trail(0);
         trail.iterator().remove();
     }
 
@@ -196,8 +195,8 @@ public class TrailDBTest {
 
     @Test
     public void getFieldShouldReturnCorrectID() {
-        ByteBuffer handle = Deencapsulation.getField(this.db, "db");
-        ByteBuffer res = ByteBuffer.allocate(4);
+        final long handle = Deencapsulation.getField(this.db, "db");
+        final ByteBuffer res = ByteBuffer.allocate(4);
         TrailDBNative.INSTANCE.getField(handle, "field1", res);
         assertEquals(1, res.getInt(0));
     }
@@ -205,13 +204,13 @@ public class TrailDBTest {
     @Test
     public void closeShouldFreeDB() {
         this.db.close();
-        assertNull(Deencapsulation.getField(this.db, "db"));
+        assertEquals(-1, (long)Deencapsulation.getField(this.db, "db"));
     }
 
     @Test
-    public void closeNullDBField() {
+    public void closeInvalidHandle() {
 
-        Deencapsulation.setField(this.db, "db", null);
+        Deencapsulation.setField(this.db, "db", -1);
         this.db.close();
     }
 
@@ -219,7 +218,7 @@ public class TrailDBTest {
     public void tearDown() throws IOException {
 
         // Clear the TrailDB files/directories created for the tests.
-        File f = new File(this.path + ".tdb");
+        final File f = new File(this.path + ".tdb");
         if (f.exists() && !f.isDirectory()) {
             f.delete();
         }


### PR DESCRIPTION
Instead of storing the handles( to db, cursors, etc), store them in a simple long.

Clean up compilation options.