### PR TITLE
Remove commons-io dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.sqooba</groupId>
 	<artifactId>traildb</artifactId>
-	<version>1.0.0</version>
+	<version>1.2.3</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -54,13 +54,6 @@
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>1.10</version>
-		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.5</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.sqooba</groupId>
 	<artifactId>traildb</artifactId>
-	<version>1.2.3</version>
+	<version>1.0.0</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The dependency commons-io:commons-io was not used in the code, so I removed it since it is pulling a lot of other dependencies